### PR TITLE
Add Vite build setup for client

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,25 @@ The current implementation includes placeholder components and systems for:
 - Turn-based battle logic with elemental advantages
 
 These modules serve as a foundation for future development and integration.
+
+## Development Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server for the client:
+   ```bash
+   npm run dev
+   ```
+   This uses Vite to serve the React/TypeScript client.
+3. In another terminal, run the Express API server:
+   ```bash
+   npm run server
+   ```
+4. Build the client for production with:
+   ```bash
+   npm run build
+   ```
+
+The compiled client output will be placed in the `dist/` directory.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Spirit Guardian Battle</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { Canvas } from '@react-three/fiber'
+import { PlayerCharacter } from './game/3d/PlayerCharacter'
+import { WorldTerrain } from './game/3d/WorldTerrain'
+import { WorldMap } from './game/components/WorldMap'
+
+const App: React.FC = () => (
+  <>
+    <Canvas shadows>
+      <ambientLight />
+      <PlayerCharacter />
+      <WorldTerrain />
+    </Canvas>
+    <WorldMap />
+  </>
+)
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "spirit-guardian-battle",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "server": "node server/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@react-three/fiber": "^8.12.0",
+    "three": "^0.157.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "typescript": "^5.1.6",
+    "vite": "^4.4.7"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["shared/*"]
+    }
+  },
+  "include": ["client/**/*", "shared/**/*"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+
+export default defineConfig({
+  root: 'client',
+  plugins: [react()],
+  build: {
+    outDir: path.resolve(__dirname, 'dist'),
+    emptyOutDir: true
+  },
+  resolve: {
+    alias: {
+      '@shared': path.resolve(__dirname, 'shared')
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- add `package.json` with React, Vite and Express dependencies
- configure project TypeScript options
- set up Vite bundler
- create basic HTML entry point and React app
- document setup instructions

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*
